### PR TITLE
(Feature)|Add support for transient dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Types to factories are one-to-many, so you may end up creating multiple types th
 ```swift
 /// TestSuite12345DependencyFactoryIndex.swift
 
-TestSuite12345DependencyFactoryIndex: DependencyFactoryIndexable {
+final class TestSuite12345DependencyFactoryIndex: DependencyFactoryIndexable {
   let index: [DependencyFactoryKey: (DependencyContainer) -> Any] = TestSuite12345DependencyFactoryIndex.makeIndex()
 
   private static func makeIndex() -> [DependencyFactoryKey: (DependencyContainer) -> Any] {
@@ -173,13 +173,14 @@ Pulling it all together, Relay provides tools to register these dynamic dependen
 These arguments are formatted as such:
 
 ```
-[program-run] [-d, --dependency] type=<type>,factory=<factory>[,scope=<scope>]
+[program-run] [-d, --dependency] type=<type>,factory=<factory>[,scope=<scope>][,lifecycle=<lifecyle>]
 ```
 
 The value passed to `--dependency` is called a **DependencyInjectionInstruction**. The input parameters describe:
 - `type`: The type identifier, which should match the target `DependencyTypeKey`
 - `factory`: The factory identifier, which should match the target `DependencyFactoryKey`
 - `scope`: The scope identifier, or "global" if not specified
+- `lifecycle`: The dependency lifecycle type (singleton|transient), or "singleton" if not specified
 
 These arguments are provided to an **InjectDependenciesArgumentParser**, which communicates with a `DynamicDependencyRegistry`. For Xcode projects, you'll need to update your `AppDelegate`:
 

--- a/Relay.xcodeproj/project.pbxproj
+++ b/Relay.xcodeproj/project.pbxproj
@@ -125,6 +125,14 @@
 		1B47E48E21700A2B00940349 /* LaunchArgumentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B47E48421700A2B00940349 /* LaunchArgumentBuilder.swift */; };
 		1B47E48F21700A2B00940349 /* LaunchArgumentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B47E48421700A2B00940349 /* LaunchArgumentBuilder.swift */; };
 		1B47E49021700A2B00940349 /* LaunchArgumentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B47E48421700A2B00940349 /* LaunchArgumentBuilder.swift */; };
+		1B6B13D3217A7A9F004C1E76 /* LifecycleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6B13D2217A7A9F004C1E76 /* LifecycleType.swift */; };
+		1B6B13D4217A7A9F004C1E76 /* LifecycleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6B13D2217A7A9F004C1E76 /* LifecycleType.swift */; };
+		1B6B13D5217A7A9F004C1E76 /* LifecycleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6B13D2217A7A9F004C1E76 /* LifecycleType.swift */; };
+		1B6B13D6217A7A9F004C1E76 /* LifecycleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6B13D2217A7A9F004C1E76 /* LifecycleType.swift */; };
+		1B6B13DD217A8BD6004C1E76 /* LifecycleTypeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6B13DC217A8BD6004C1E76 /* LifecycleTypeExtensions.swift */; };
+		1B6B13DE217A8BD6004C1E76 /* LifecycleTypeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6B13DC217A8BD6004C1E76 /* LifecycleTypeExtensions.swift */; };
+		1B6B13DF217A8BD6004C1E76 /* LifecycleTypeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6B13DC217A8BD6004C1E76 /* LifecycleTypeExtensions.swift */; };
+		1B6B13E0217A8BD6004C1E76 /* LifecycleTypeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6B13DC217A8BD6004C1E76 /* LifecycleTypeExtensions.swift */; };
 		1B7798102171480D00DE8477 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B77980D2171480D00DE8477 /* XCTestManifests.swift */; };
 /* End PBXBuildFile section */
 
@@ -199,6 +207,8 @@
 		1B47E48221700A2B00940349 /* LaunchArgument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchArgument.swift; sourceTree = "<group>"; };
 		1B47E48321700A2B00940349 /* DependencyInstructionLaunchArgument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DependencyInstructionLaunchArgument.swift; sourceTree = "<group>"; };
 		1B47E48421700A2B00940349 /* LaunchArgumentBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchArgumentBuilder.swift; sourceTree = "<group>"; };
+		1B6B13D2217A7A9F004C1E76 /* LifecycleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleType.swift; sourceTree = "<group>"; };
+		1B6B13DC217A8BD6004C1E76 /* LifecycleTypeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleTypeExtensions.swift; sourceTree = "<group>"; };
 		1B779805217147D900DE8477 /* LinuxMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinuxMain.swift; sourceTree = "<group>"; };
 		1B77980D2171480D00DE8477 /* XCTestManifests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -329,13 +339,14 @@
 		1B47E3B4216FE09300940349 /* Relay */ = {
 			isa = PBXGroup;
 			children = (
+				1B47E3C5216FE34700940349 /* DynamicInjection */,
+				1B47E481217009FA00940349 /* LaunchArguments */,
+				1B47E3BE216FE34600940349 /* Resources */,
 				1B47E3BC216FE34600940349 /* DependencyContainer.swift */,
 				1B47E3BB216FE34500940349 /* DependencyContainerScope.swift */,
 				1B47E3BD216FE34600940349 /* DependencyKey.swift */,
 				1B47E3D8216FE34700940349 /* DependencyRegistryType.swift */,
-				1B47E3C5216FE34700940349 /* DynamicInjection */,
-				1B47E481217009FA00940349 /* LaunchArguments */,
-				1B47E3BE216FE34600940349 /* Resources */,
+				1B6B13D2217A7A9F004C1E76 /* LifecycleType.swift */,
 			);
 			path = Relay;
 			sourceTree = "<group>";
@@ -377,6 +388,7 @@
 				1B47E3CD216FE34700940349 /* CommandLine+ArgumentParser.swift */,
 				1B47E3CE216FE34700940349 /* DependencyInjectionInstruction.swift */,
 				1B47E3CF216FE34700940349 /* ArgumentParser.swift */,
+				1B6B13DC217A8BD6004C1E76 /* LifecycleTypeExtensions.swift */,
 			);
 			path = CommandLine;
 			sourceTree = "<group>";
@@ -781,6 +793,7 @@
 				1B47E48D21700A2B00940349 /* LaunchArgumentBuilder.swift in Sources */,
 				1B47E415216FE34700940349 /* CommandLine+ArgumentParser.swift in Sources */,
 				1B47E3E1216FE34700940349 /* DependencyKey.swift in Sources */,
+				1B6B13DD217A8BD6004C1E76 /* LifecycleTypeExtensions.swift in Sources */,
 				1B47E3FD216FE34700940349 /* DependencyFactoryIndexable.swift in Sources */,
 				1B47E401216FE34700940349 /* DependencyDefinition.swift in Sources */,
 				1B47E48921700A2B00940349 /* DependencyInstructionLaunchArgument.swift in Sources */,
@@ -791,6 +804,7 @@
 				1B47E419216FE34700940349 /* DependencyInjectionInstruction.swift in Sources */,
 				1B47E48521700A2B00940349 /* LaunchArgument.swift in Sources */,
 				1B47E421216FE34700940349 /* DependencyTypeIndexable.swift in Sources */,
+				1B6B13D3217A7A9F004C1E76 /* LifecycleType.swift in Sources */,
 				1B47E439216FE34700940349 /* DynamicDependencyRegistry.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -809,6 +823,7 @@
 				1B47E48E21700A2B00940349 /* LaunchArgumentBuilder.swift in Sources */,
 				1B47E416216FE34700940349 /* CommandLine+ArgumentParser.swift in Sources */,
 				1B47E3E2216FE34700940349 /* DependencyKey.swift in Sources */,
+				1B6B13DE217A8BD6004C1E76 /* LifecycleTypeExtensions.swift in Sources */,
 				1B47E3FE216FE34700940349 /* DependencyFactoryIndexable.swift in Sources */,
 				1B47E402216FE34700940349 /* DependencyDefinition.swift in Sources */,
 				1B47E48A21700A2B00940349 /* DependencyInstructionLaunchArgument.swift in Sources */,
@@ -819,6 +834,7 @@
 				1B47E41A216FE34700940349 /* DependencyInjectionInstruction.swift in Sources */,
 				1B47E48621700A2B00940349 /* LaunchArgument.swift in Sources */,
 				1B47E422216FE34700940349 /* DependencyTypeIndexable.swift in Sources */,
+				1B6B13D4217A7A9F004C1E76 /* LifecycleType.swift in Sources */,
 				1B47E43A216FE34700940349 /* DynamicDependencyRegistry.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -837,6 +853,7 @@
 				1B47E48F21700A2B00940349 /* LaunchArgumentBuilder.swift in Sources */,
 				1B47E417216FE34700940349 /* CommandLine+ArgumentParser.swift in Sources */,
 				1B47E3E3216FE34700940349 /* DependencyKey.swift in Sources */,
+				1B6B13DF217A8BD6004C1E76 /* LifecycleTypeExtensions.swift in Sources */,
 				1B47E3FF216FE34700940349 /* DependencyFactoryIndexable.swift in Sources */,
 				1B47E403216FE34700940349 /* DependencyDefinition.swift in Sources */,
 				1B47E48B21700A2B00940349 /* DependencyInstructionLaunchArgument.swift in Sources */,
@@ -847,6 +864,7 @@
 				1B47E41B216FE34700940349 /* DependencyInjectionInstruction.swift in Sources */,
 				1B47E48721700A2B00940349 /* LaunchArgument.swift in Sources */,
 				1B47E423216FE34700940349 /* DependencyTypeIndexable.swift in Sources */,
+				1B6B13D5217A7A9F004C1E76 /* LifecycleType.swift in Sources */,
 				1B47E43B216FE34700940349 /* DynamicDependencyRegistry.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -865,6 +883,7 @@
 				1B47E49021700A2B00940349 /* LaunchArgumentBuilder.swift in Sources */,
 				1B47E418216FE34700940349 /* CommandLine+ArgumentParser.swift in Sources */,
 				1B47E3E4216FE34700940349 /* DependencyKey.swift in Sources */,
+				1B6B13E0217A8BD6004C1E76 /* LifecycleTypeExtensions.swift in Sources */,
 				1B47E400216FE34700940349 /* DependencyFactoryIndexable.swift in Sources */,
 				1B47E404216FE34700940349 /* DependencyDefinition.swift in Sources */,
 				1B47E48C21700A2B00940349 /* DependencyInstructionLaunchArgument.swift in Sources */,
@@ -875,6 +894,7 @@
 				1B47E41C216FE34700940349 /* DependencyInjectionInstruction.swift in Sources */,
 				1B47E48821700A2B00940349 /* LaunchArgument.swift in Sources */,
 				1B47E424216FE34700940349 /* DependencyTypeIndexable.swift in Sources */,
+				1B6B13D6217A7A9F004C1E76 /* LifecycleType.swift in Sources */,
 				1B47E43C216FE34700940349 /* DynamicDependencyRegistry.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Relay/DynamicInjection/CommandLine/InjectDependenciesArgumentParser.swift
+++ b/Sources/Relay/DynamicInjection/CommandLine/InjectDependenciesArgumentParser.swift
@@ -50,7 +50,8 @@ public final class InjectDependenciesArgumentParser: ArgumentParser {
 
             for instruction in instructions {
                 let definition = DependencyDefinition(typeIdentifier: DependencyTypeKey(instruction.typeIdentifier),
-                                                      factoryIdentifier: DependencyFactoryKey(instruction.factoryIdentifier))
+                                                      factoryIdentifier: DependencyFactoryKey(instruction.factoryIdentifier),
+                                                      lifecycle: LifecycleType(identifier: instruction.lifecycle) ?? .singleton)
                 definitions.append(definition)
             }
 

--- a/Sources/Relay/DynamicInjection/CommandLine/LifecycleTypeExtensions.swift
+++ b/Sources/Relay/DynamicInjection/CommandLine/LifecycleTypeExtensions.swift
@@ -1,0 +1,35 @@
+//
+//  LifecycleTypeExtensions.swift
+//  Relay
+//
+//  Created by John Hammerlund on 10/19/18.
+//
+
+import Foundation
+
+extension LifecycleType {
+
+    private static let transientIdentifier = "transient"
+    private static let singletonIdentifier = "singleton"
+
+    init?(identifier: String) {
+        switch identifier {
+        case LifecycleType.transientIdentifier:
+            self = .transient
+        case LifecycleType.singletonIdentifier:
+            self = .singleton
+        default:
+            return nil
+        }
+    }
+
+    var identifier: String {
+        switch self {
+        case .transient:
+            return LifecycleType.transientIdentifier
+        case .singleton:
+            return LifecycleType.singletonIdentifier
+        }
+    }
+
+}

--- a/Sources/Relay/DynamicInjection/DependencyDefinition.swift
+++ b/Sources/Relay/DynamicInjection/DependencyDefinition.swift
@@ -15,15 +15,18 @@ public struct DependencyDefinition {
     public let typeIdentifier: DependencyTypeKey
     /// The concrete factory identifier
     public let factoryIdentifier: DependencyFactoryKey
+    ///
+    public let lifecycle: LifecycleType
 
     /// Creates a new DependencyDefinition
     ///
     /// - Parameters:
     ///   - typeIdentifier: The abstract type identifier
     ///   - factoryIdentifier: The concrete factory identifier
-    public init(typeIdentifier: DependencyTypeKey, factoryIdentifier: DependencyFactoryKey) {
+    public init(typeIdentifier: DependencyTypeKey, factoryIdentifier: DependencyFactoryKey, lifecycle: LifecycleType) {
         self.typeIdentifier = typeIdentifier
         self.factoryIdentifier = factoryIdentifier
+        self.lifecycle = lifecycle
     }
 
 }

--- a/Sources/Relay/DynamicInjection/DynamicDependencyRegistry.swift
+++ b/Sources/Relay/DynamicInjection/DynamicDependencyRegistry.swift
@@ -33,7 +33,7 @@ public final class DynamicDependencyRegistry: DependencyRegistryType {
                 let type = try index.lookup(type: definition.typeIdentifier)
                 let factory = try index.lookup(factory: definition.factoryIdentifier)
 
-                container.register(key: DependencyKey(type), with: factory)
+                container.register(key: DependencyKey(type), lifecycle: definition.lifecycle, with: factory)
             }
         }
 

--- a/Sources/Relay/LifecycleType.swift
+++ b/Sources/Relay/LifecycleType.swift
@@ -1,0 +1,17 @@
+//
+//  LifecycleType.swift
+//  Relay
+//
+//  Created by John Hammerlund on 10/19/18.
+//
+
+import Foundation
+
+/// Determines a dependency lifetime
+///
+/// - transient: Dependencies are short-lived and spawn per-resolution
+/// - singleton: Dependencies are created once and only once
+public enum LifecycleType: CaseIterable {
+    case transient
+    case singleton
+}

--- a/Tests/RelayTests/DependencyContainerTests.swift
+++ b/Tests/RelayTests/DependencyContainerTests.swift
@@ -15,6 +15,7 @@ private protocol TypeC { }
 private protocol TypeD: class { }
 private protocol TypeE: class { }
 private protocol TypeF: class { }
+private protocol TypeG: class { }
 
 // swiftlint:disable nesting
 final class DependencyContainerTests: XCTestCase {
@@ -52,12 +53,23 @@ final class DependencyContainerTests: XCTestCase {
         XCTAssert(sut.resolve(TypeC.self) is ImplementsC)
     }
 
-    func testLazyLoadsDependencies() throws {
+    func testLazyLoadsSingletonDependencies() throws {
         class ImplementsD: TypeD { }
 
         DependencyContainer.global.register(TypeD.self) { _ in ImplementsD() }
         let dependency = DependencyContainer.global.resolve(TypeD.self)
         XCTAssert(dependency === DependencyContainer.global.resolve(TypeD.self))
+    }
+
+    func testSpawnsTransientDependencies() throws {
+        class ImplementsG: TypeG { }
+
+        let scope = DependencyContainerScope(#function)
+        let sut = DependencyContainer.container(for: scope)
+
+        sut.register(TypeG.self, lifecycle: .transient) { _ in ImplementsG() }
+
+        XCTAssertFalse(sut.resolve(TypeG.self) === sut.resolve(TypeG.self))
     }
 
     func testResolvesLazyCircularDependencies() throws {

--- a/Tests/RelayTests/DependencyInjectionInstructionTests.swift
+++ b/Tests/RelayTests/DependencyInjectionInstructionTests.swift
@@ -12,25 +12,35 @@ import XCTest
 final class DependencyInjectionInstructionTests: XCTestCase {
 
     func testParsesCommandLineIdentifiers() throws {
-        let validIdentifier = "type=sampleType,factory=sampleFactory,scope=👌🏻"
+        let validIdentifier = "type=sampleType,factory=sampleFactory,scope=👌🏻,lifecycle=transient"
+        let validIdentifierWithoutLifecycle = "type=sampleType,factory=sampleFactory,scope=👌🏻"
         let validIdentiferWithoutScope = "type  =  sampleType2,     factory  =  sampleFactory2"
 
         var sut = try DependencyInjectionInstruction(commandLineIdentifier: validIdentifier)
         XCTAssertEqual(sut.typeIdentifier, "sampleType")
         XCTAssertEqual(sut.factoryIdentifier, "sampleFactory")
         XCTAssertEqual(sut.scope, "👌🏻")
+        XCTAssertEqual(sut.lifecycle, "transient")
+
+        sut = try DependencyInjectionInstruction(commandLineIdentifier: validIdentifierWithoutLifecycle)
+        XCTAssertEqual(sut.typeIdentifier, "sampleType")
+        XCTAssertEqual(sut.factoryIdentifier, "sampleFactory")
+        XCTAssertEqual(sut.scope, "👌🏻")
+        XCTAssertEqual(sut.lifecycle, "singleton")
 
         sut = try DependencyInjectionInstruction(commandLineIdentifier: validIdentiferWithoutScope)
         XCTAssertEqual(sut.typeIdentifier, "sampleType2")
         XCTAssertEqual(sut.factoryIdentifier, "sampleFactory2")
         XCTAssertEqual(sut.scope, "global")
+        XCTAssertEqual(sut.lifecycle, "singleton")
     }
 
     func testThrowsOnMalformattedParameters() throws {
         let malformattedIdentifiers = [
             "type=sampleType=,factory=sampleFactory",
             "type=,factory=sampleFactory",
-            "="
+            "=",
+            "type=sampleType,factory=sampleFactory,lifecycle=dead"
         ]
 
         for identifier in malformattedIdentifiers {

--- a/Tests/RelayTests/DynamicDependencyRegistryTests.swift
+++ b/Tests/RelayTests/DynamicDependencyRegistryTests.swift
@@ -34,11 +34,11 @@ final class DynamicDependencyRegistryTests: XCTestCase {
         let customScope = DependencyContainerScope(#function)
         let metaContainers = [
             DependencyMetaContainer(scope: .global, definitions: [
-                DependencyDefinition(typeIdentifier: .dynamicTypeA, factoryIdentifier: .dynamicFactoryA),
-                DependencyDefinition(typeIdentifier: .dynamicTypeB, factoryIdentifier: .dynamicFactoryB)
+                DependencyDefinition(typeIdentifier: .dynamicTypeA, factoryIdentifier: .dynamicFactoryA, lifecycle: .singleton),
+                DependencyDefinition(typeIdentifier: .dynamicTypeB, factoryIdentifier: .dynamicFactoryB, lifecycle: .singleton)
                 ]),
             DependencyMetaContainer(scope: customScope, definitions: [
-                DependencyDefinition(typeIdentifier: .dynamicTypeC, factoryIdentifier: .dynamicFactoryC)
+                DependencyDefinition(typeIdentifier: .dynamicTypeC, factoryIdentifier: .dynamicFactoryC, lifecycle: .singleton)
                 ])
         ]
 
@@ -57,7 +57,7 @@ final class DynamicDependencyRegistryTests: XCTestCase {
         let factoryA: (DependencyContainer) -> Any = { _ in ImplementsDynamicTypeA() }
 
         let metaContainer = DependencyMetaContainer(scope: .global, definitions: [
-            DependencyDefinition(typeIdentifier: .dynamicTypeA, factoryIdentifier: .dynamicFactoryA)
+            DependencyDefinition(typeIdentifier: .dynamicTypeA, factoryIdentifier: .dynamicFactoryA, lifecycle: .singleton)
             ])
 
         let factoryIndex = TestDynamicFactoryIndex(index: [.dynamicFactoryA: factoryA])
@@ -70,7 +70,7 @@ final class DynamicDependencyRegistryTests: XCTestCase {
 
     func testThrowsForUnknownFactories() throws {
         let metaContainer = DependencyMetaContainer(scope: .global, definitions: [
-            DependencyDefinition(typeIdentifier: .dynamicTypeA, factoryIdentifier: .dynamicFactoryA)
+            DependencyDefinition(typeIdentifier: .dynamicTypeA, factoryIdentifier: .dynamicFactoryA, lifecycle: .singleton)
             ])
 
         let typeIndex = TestDynamicTypeIndex(index: [.dynamicTypeA: DynamicTypeA.self])

--- a/Tests/RelayTests/XCTestManifests.swift
+++ b/Tests/RelayTests/XCTestManifests.swift
@@ -11,10 +11,11 @@ extension CommandLineExtensionTests {
 extension DependencyContainerTests {
     static let __allTests = [
         ("testComponentContainersFallBackToGlobalScope", testComponentContainersFallBackToGlobalScope),
-        ("testLazyLoadsDependencies", testLazyLoadsDependencies),
+        ("testLazyLoadsSingletonDependencies", testLazyLoadsSingletonDependencies),
         ("testRegistersTypes", testRegistersTypes),
         ("testRegistersTypesAtComponentScope", testRegistersTypesAtComponentScope),
         ("testResolvesLazyCircularDependencies", testResolvesLazyCircularDependencies),
+        ("testSpawnsTransientDependencies", testSpawnsTransientDependencies),
     ]
 }
 


### PR DESCRIPTION
This pull request includes (pick all that apply):

- [ ] Bugfixes
- [x] New features
- [x] Breaking changes
- [x] Documentation updates
- [x] Unit tests
- [ ] Other

### Summary
Even at scope, Relay currently only supports singleton dependencies, making it more of a service locator than an IoC Container framework. This adds a new parameter into the mix across all layers, `LifecycleType`, which gives more control over dependency lifecycles. By default, registered dependencies have a lifecycle type of `.singleton`, which maintains the current behavior of lazy-loaded singleton dependencies.

However, the caller can now also register a dependency as `.transient`. Transient dependencies are recreated every time they are resolved. At the container level, this means we simply ignore the lazy-loaded dependencies and execute the factory for every request.

### Implementation
- Added a new enum, `LifecycleType`
- Updated `DependencyContainer.resolve()` functions to take an optional `lifecycle:`
- Added `lifecycle` as a required field to `DependencyDefinition`
- Added `lifecycle` as an optional parameter for `DependencyInjectionInstruction`

### Test Plan
Added:
```
DependencyContainerTests.testSpawnsTransientDependencies()
```
Also updated existing tests to support and test for new fields
