### PR TITLE
(Feature)|Flatten optional type-mapping

### DIFF
--- a/Relay.xcodeproj/project.pbxproj
+++ b/Relay.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1B170ECB21ECFC4D00564994 /* OptionalExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B170ECA21ECFC4D00564994 /* OptionalExtensions.swift */; };
+		1B170ECC21ECFC4D00564994 /* OptionalExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B170ECA21ECFC4D00564994 /* OptionalExtensions.swift */; };
+		1B170ECD21ECFC4D00564994 /* OptionalExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B170ECA21ECFC4D00564994 /* OptionalExtensions.swift */; };
+		1B170ECE21ECFC4D00564994 /* OptionalExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B170ECA21ECFC4D00564994 /* OptionalExtensions.swift */; };
+		1B170ED021ED047000564994 /* OptionalExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B170ECF21ED047000564994 /* OptionalExtensionTests.swift */; };
+		1B170ED121ED047000564994 /* OptionalExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B170ECF21ED047000564994 /* OptionalExtensionTests.swift */; };
+		1B170ED221ED047000564994 /* OptionalExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B170ECF21ED047000564994 /* OptionalExtensionTests.swift */; };
 		1B2D6B982170FBB900CCB604 /* CommandLineExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B2D6B972170FBB900CCB604 /* CommandLineExtensionTests.swift */; };
 		1B2D6B992170FBB900CCB604 /* CommandLineExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B2D6B972170FBB900CCB604 /* CommandLineExtensionTests.swift */; };
 		1B2D6B9A2170FBB900CCB604 /* CommandLineExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B2D6B972170FBB900CCB604 /* CommandLineExtensionTests.swift */; };
@@ -161,6 +168,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1B170ECA21ECFC4D00564994 /* OptionalExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalExtensions.swift; sourceTree = "<group>"; };
+		1B170ECF21ED047000564994 /* OptionalExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalExtensionTests.swift; sourceTree = "<group>"; };
 		1B2D6B972170FBB900CCB604 /* CommandLineExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandLineExtensionTests.swift; sourceTree = "<group>"; };
 		1B2D6B9B2171011800CCB604 /* DependencyInstructionLaunchArgumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyInstructionLaunchArgumentTests.swift; sourceTree = "<group>"; };
 		1B2D6B9F217102B600CCB604 /* LaunchArgumentBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchArgumentBuilderTests.swift; sourceTree = "<group>"; };
@@ -269,6 +278,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1B170EC921ECFC3500564994 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				1B170ECA21ECFC4D00564994 /* OptionalExtensions.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		1B2D6B962170FB9200CCB604 /* CommandLine */ = {
 			isa = PBXGroup;
 			children = (
@@ -329,6 +346,7 @@
 				1B47E443216FE49A00940349 /* DynamicDependencyIndexTests.swift */,
 				1B47E44E216FE49A00940349 /* DynamicDependencyRegistryTests.swift */,
 				1B47E44F216FE49A00940349 /* InjectDependenciesArgumentParserTests.swift */,
+				1B170ECF21ED047000564994 /* OptionalExtensionTests.swift */,
 				1B47E445216FE49A00940349 /* Resources */,
 				1B47E44C216FE49A00940349 /* Util */,
 				1B77980D2171480D00DE8477 /* XCTestManifests.swift */,
@@ -340,6 +358,7 @@
 			isa = PBXGroup;
 			children = (
 				1B47E3C5216FE34700940349 /* DynamicInjection */,
+				1B170EC921ECFC3500564994 /* Extensions */,
 				1B47E481217009FA00940349 /* LaunchArguments */,
 				1B47E3BE216FE34600940349 /* Resources */,
 				1B47E3BC216FE34600940349 /* DependencyContainer.swift */,
@@ -784,6 +803,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1B47E3DD216FE34700940349 /* DependencyContainer.swift in Sources */,
+				1B170ECB21ECFC4D00564994 /* OptionalExtensions.swift in Sources */,
 				1B47E3D9216FE34700940349 /* DependencyContainerScope.swift in Sources */,
 				1B47E435216FE34700940349 /* DependencyFactoryKey.swift in Sources */,
 				1B47E43D216FE34700940349 /* DependencyRegistryType.swift in Sources */,
@@ -814,6 +834,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1B47E3DE216FE34700940349 /* DependencyContainer.swift in Sources */,
+				1B170ECC21ECFC4D00564994 /* OptionalExtensions.swift in Sources */,
 				1B47E3DA216FE34700940349 /* DependencyContainerScope.swift in Sources */,
 				1B47E436216FE34700940349 /* DependencyFactoryKey.swift in Sources */,
 				1B47E43E216FE34700940349 /* DependencyRegistryType.swift in Sources */,
@@ -844,6 +865,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1B47E3DF216FE34700940349 /* DependencyContainer.swift in Sources */,
+				1B170ECD21ECFC4D00564994 /* OptionalExtensions.swift in Sources */,
 				1B47E3DB216FE34700940349 /* DependencyContainerScope.swift in Sources */,
 				1B47E437216FE34700940349 /* DependencyFactoryKey.swift in Sources */,
 				1B47E43F216FE34700940349 /* DependencyRegistryType.swift in Sources */,
@@ -874,6 +896,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1B47E3E0216FE34700940349 /* DependencyContainer.swift in Sources */,
+				1B170ECE21ECFC4D00564994 /* OptionalExtensions.swift in Sources */,
 				1B47E3DC216FE34700940349 /* DependencyContainerScope.swift in Sources */,
 				1B47E438216FE34700940349 /* DependencyFactoryKey.swift in Sources */,
 				1B47E440216FE34700940349 /* DependencyRegistryType.swift in Sources */,
@@ -908,6 +931,7 @@
 				1B47E46E216FE49B00940349 /* DynamicDependencyTestUtilities.swift in Sources */,
 				1B2D6B9C2171011800CCB604 /* DependencyInstructionLaunchArgumentTests.swift in Sources */,
 				1B47E468216FE49B00940349 /* DependencyContainerTests.swift in Sources */,
+				1B170ED021ED047000564994 /* OptionalExtensionTests.swift in Sources */,
 				1B47E456216FE49A00940349 /* DynamicDependencyIndexTests.swift in Sources */,
 				1B2D6B982170FBB900CCB604 /* CommandLineExtensionTests.swift in Sources */,
 				1B2D6BA0217102B600CCB604 /* LaunchArgumentBuilderTests.swift in Sources */,
@@ -924,6 +948,7 @@
 				1B47E46F216FE49B00940349 /* DynamicDependencyTestUtilities.swift in Sources */,
 				1B2D6B9D2171011800CCB604 /* DependencyInstructionLaunchArgumentTests.swift in Sources */,
 				1B47E469216FE49B00940349 /* DependencyContainerTests.swift in Sources */,
+				1B170ED121ED047000564994 /* OptionalExtensionTests.swift in Sources */,
 				1B47E457216FE49A00940349 /* DynamicDependencyIndexTests.swift in Sources */,
 				1B2D6B992170FBB900CCB604 /* CommandLineExtensionTests.swift in Sources */,
 				1B2D6BA1217102B600CCB604 /* LaunchArgumentBuilderTests.swift in Sources */,
@@ -937,6 +962,7 @@
 			files = (
 				1B47E455216FE49A00940349 /* DependencyInjectionInstructionTests.swift in Sources */,
 				1B47E477216FE93800940349 /* DynamicDependencyTestUtilities.swift in Sources */,
+				1B170ED221ED047000564994 /* OptionalExtensionTests.swift in Sources */,
 				1B47E473216FE49B00940349 /* DynamicDependencyRegistryTests.swift in Sources */,
 				1B2D6B9E2171011800CCB604 /* DependencyInstructionLaunchArgumentTests.swift in Sources */,
 				1B47E46A216FE49B00940349 /* DependencyContainerTests.swift in Sources */,

--- a/Sources/Relay/DependencyContainer.swift
+++ b/Sources/Relay/DependencyContainer.swift
@@ -43,7 +43,8 @@ public final class DependencyContainer {
     }
 
     private func keyFor<T>(_ type: T.Type = T.self) -> DependencyKey {
-        return DependencyKey(type)
+        let baseType = T?.underlyingType
+        return DependencyKey(baseType)
     }
 
     /// Registers a concrete type for an abstract dependency
@@ -79,7 +80,7 @@ public final class DependencyContainer {
         let key = keyFor(dependencyType)
         let lifecycle = lifecycles[key] ?? .singleton
 
-        if lifecycle == .singleton, let resolved = singletonDependencies[key] as? T {
+        if lifecycle == .singleton, singletonDependencies[key] != nil, let resolved = singletonDependencies[key] as? T {
             return resolved
         }
         guard let found = factories[keyFor(dependencyType)]?(self) else {

--- a/Sources/Relay/Extensions/OptionalExtensions.swift
+++ b/Sources/Relay/Extensions/OptionalExtensions.swift
@@ -1,0 +1,36 @@
+//
+//  OptionalExtensions.swift
+//  Relay
+//
+//  Created by John Hammerlund on 1/14/19.
+//
+
+import Foundation
+
+/// Allows for compile-time type-erasure on `Optional`, useful for type-checking
+protocol OptionalType {
+
+    /// The wrapped type (erased)
+    static var wrapped: Any.Type { get }
+
+}
+
+extension Optional: OptionalType {
+
+    static var wrapped: Any.Type {
+        return Wrapped.self
+    }
+
+}
+
+extension OptionalType {
+
+    /// The underlying type, which may be nested in multiple Optionals
+    static var underlyingType: Any.Type {
+        if let wrapped = wrapped as? OptionalType.Type {
+            return wrapped.underlyingType
+        }
+        return wrapped
+    }
+
+}

--- a/Tests/RelayTests/DependencyContainerTests.swift
+++ b/Tests/RelayTests/DependencyContainerTests.swift
@@ -16,6 +16,7 @@ private protocol TypeD: class { }
 private protocol TypeE: class { }
 private protocol TypeF: class { }
 private protocol TypeG: class { }
+private protocol TypeH: class { }
 
 // swiftlint:disable nesting
 final class DependencyContainerTests: XCTestCase {
@@ -101,6 +102,27 @@ final class DependencyContainerTests: XCTestCase {
         }
 
         XCTAssert(implementsF.nested === sut.resolve(TypeE.self))
+    }
+
+    func testFlattensOptionalTypeMapping() throws {
+        class ImplementsH: TypeH { }
+        class AlsoImplementsH: TypeH { }
+
+        let scope = DependencyContainerScope(#function)
+        let sut = DependencyContainer.container(for: scope)
+
+        sut.register(TypeH.self) { _ in ImplementsH() }
+
+        guard let resolvedOptional = sut.resolve(TypeH??.self),
+            let resolved = resolvedOptional else {
+            XCTFail("Failed to register optional")
+            return
+        }
+        XCTAssert(resolved is ImplementsH)
+
+        sut.register(TypeH??.self) { _ in AlsoImplementsH() }
+
+        XCTAssert(sut.resolve(TypeH.self) is AlsoImplementsH)
     }
 
 }

--- a/Tests/RelayTests/OptionalExtensionTests.swift
+++ b/Tests/RelayTests/OptionalExtensionTests.swift
@@ -1,0 +1,33 @@
+//
+//  OptionalExtensionTests.swift
+//  Relay
+//
+//  Created by John Hammerlund on 1/14/19.
+//
+
+import XCTest
+@testable import Relay
+
+final class OptionalExtensionTests: XCTestCase {
+
+    func testErasedTypeIsWrappedType() {
+        let optionalIntType = Int?.self
+        let doubleOptionalStringType = String??.self
+
+        XCTAssert(optionalIntType.wrapped is Int.Type)
+        XCTAssert(doubleOptionalStringType.wrapped is String?.Type)
+    }
+
+    func testUnwrapsUnderlyingTypeFromNestedOptionals() {
+        let optionalIntType = Int?.self
+        let doubleOptionalStringType = String??.self
+        let tripleOptionalDateType = Date???.self
+        let quadrupleOptionalDoubleType = Double????.self
+
+        XCTAssert(optionalIntType.underlyingType is Int.Type)
+        XCTAssert(doubleOptionalStringType.underlyingType is String.Type)
+        XCTAssert(tripleOptionalDateType.underlyingType is Date.Type)
+        XCTAssert(quadrupleOptionalDoubleType.underlyingType is Double.Type)
+    }
+
+}


### PR DESCRIPTION
This pull request includes (pick all that apply):

- [ ] Bugfixes
- [x] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [x] Unit tests
- [ ] Other

### Summary
This adds a new internal extension to `Optional` to remove the generic type constraint, allowing for dynamically checking whether any type (concrete or generic) is an optional. With this, we can retrieve the underlying type of any level of nested optionals. Example:

```swift
print(Int?.underlyingType is Int.Type) // true
print(Double??.underlyingType is Double.Type) // true
print(String???.underlyingType is String??.Type) // false
```

For Relay, this prevents against an easy mistake of registering or resolving an optional type using inference, which previously would cause type-mapping to fail:

```swift
DependencyContainer.global.register(MyType.self) { _ in ImplementsMyType() }

let dependency: MyType? = DependencyContainer.global.resolve() // would always return nil
```

Now, `DependencyContainer` uses the same key for nested optionals as it would for their underlying types:

```swift
DependencyContainer.global.register(MyType.self) { _ in ImplementsMyType() }

let dependency: MyType? = DependencyContainer.global.resolve() // returns an ImplementsMyType
```

### Implementation
Adds an internal `OptionalType` protocol, used for erasing generic `Wrapped` variable & allowing for dynamic type comparisons

### Test Plan
Added unit tests:
```swift
DependencyContainerTests.testFlattensOptionalTypeMapping()
OptionalExtensionTests.testErasedTypeIsWrappedType()
OptionalExtensionTests.testUnwrapsUnderlyingTypeFromNestedOptionals()
```