### PR TITLE
(Maint)|Add license to podspec

### DIFF
--- a/Relay.podspec
+++ b/Relay.podspec
@@ -3,7 +3,7 @@ $version = '0.2.1'
 Pod::Spec.new do |spec|
 	spec.name = 'Relay'
 	spec.version = $version
-	# spec.license = 'MIT'
+	spec.license = { :type => 'MIT', :file => 'LICENSE' }
 	spec.homepage = 'https://github.com/mindbody/Relay'
 	spec.author = 'Relay Contributors'
 	spec.summary = 'Swift Dynamic Dependency Injection for modern testing'


### PR DESCRIPTION
This pull request includes (pick all that apply):

- [ ] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [x] Other

### Summary
Updates the podspec with the MIT license, which is needed for publishing.

### Test Plan
Podspec lint should pass:
`$ pod lib lint`
