### PR TITLE
(Feature)|Add @Injected property wrapper for auto-injection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode11.1
+osx_image: xcode11.3
 cache:
   - bundler: true
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode11.3
+osx_image: xcode11.1
 cache:
   - bundler: true
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode10.2
+osx_image: xcode11.3
 cache:
   - bundler: true
 install:

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,6 @@ def build_matrix
       :scheme => "#{$framework}-iOS",
       :run_tests => true,
       :destinations => [
-        "OS=10.3.1,name=iPhone 5s",
         "OS=latest,name=iPad Air 2"
       ]
     },
@@ -22,7 +21,6 @@ def build_matrix
       :scheme => "#{$framework}-tvOS",
       :run_tests => true,
       :destinations => [
-        "OS=10.2,name=Apple TV 1080p",
         "OS=latest,name=Apple TV 4K"
       ]
     },
@@ -30,7 +28,7 @@ def build_matrix
       :scheme => "#{$framework}-watchOS",
       :run_tests => false,
       :destinations => [
-        "OS=latest,name=Apple Watch Series 2 - 38mm"
+        "OS=latest,name=Apple Watch Series 5 - 40mm"
       ]
     }
   ]

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ def build_matrix
       :scheme => "#{$framework}-iOS",
       :run_tests => true,
       :destinations => [
-        "OS=latest,name=iPad Air 2"
+        "OS=latest,name=iPhone 11 Pro Max"
       ]
     },
     {

--- a/Relay.xcodeproj/project.pbxproj
+++ b/Relay.xcodeproj/project.pbxproj
@@ -132,6 +132,9 @@
 		1B47E48E21700A2B00940349 /* LaunchArgumentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B47E48421700A2B00940349 /* LaunchArgumentBuilder.swift */; };
 		1B47E48F21700A2B00940349 /* LaunchArgumentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B47E48421700A2B00940349 /* LaunchArgumentBuilder.swift */; };
 		1B47E49021700A2B00940349 /* LaunchArgumentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B47E48421700A2B00940349 /* LaunchArgumentBuilder.swift */; };
+		1B5F7A8D23A9DD1B00E1E98B /* InjectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5F7A8C23A9DD1B00E1E98B /* InjectedTests.swift */; };
+		1B5F7A8E23A9DD1B00E1E98B /* InjectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5F7A8C23A9DD1B00E1E98B /* InjectedTests.swift */; };
+		1B5F7A8F23A9DD1B00E1E98B /* InjectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5F7A8C23A9DD1B00E1E98B /* InjectedTests.swift */; };
 		1B6B13D3217A7A9F004C1E76 /* LifecycleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6B13D2217A7A9F004C1E76 /* LifecycleType.swift */; };
 		1B6B13D4217A7A9F004C1E76 /* LifecycleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6B13D2217A7A9F004C1E76 /* LifecycleType.swift */; };
 		1B6B13D5217A7A9F004C1E76 /* LifecycleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6B13D2217A7A9F004C1E76 /* LifecycleType.swift */; };
@@ -144,6 +147,10 @@
 		1B80388D22B981EA00A48C56 /* DynamicTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B80388C22B981EA00A48C56 /* DynamicTypes.swift */; };
 		1B80388E22B981EA00A48C56 /* DynamicTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B80388C22B981EA00A48C56 /* DynamicTypes.swift */; };
 		1B80388F22B981EA00A48C56 /* DynamicTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B80388C22B981EA00A48C56 /* DynamicTypes.swift */; };
+		1BBFD51523A9A11700A7C3ED /* Injected.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBFD51423A9A11700A7C3ED /* Injected.swift */; };
+		1BBFD51623A9A11700A7C3ED /* Injected.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBFD51423A9A11700A7C3ED /* Injected.swift */; };
+		1BBFD51723A9A11700A7C3ED /* Injected.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBFD51423A9A11700A7C3ED /* Injected.swift */; };
+		1BBFD51823A9A11700A7C3ED /* Injected.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBFD51423A9A11700A7C3ED /* Injected.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -219,11 +226,13 @@
 		1B47E48221700A2B00940349 /* LaunchArgument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchArgument.swift; sourceTree = "<group>"; };
 		1B47E48321700A2B00940349 /* DependencyInstructionLaunchArgument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DependencyInstructionLaunchArgument.swift; sourceTree = "<group>"; };
 		1B47E48421700A2B00940349 /* LaunchArgumentBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchArgumentBuilder.swift; sourceTree = "<group>"; };
+		1B5F7A8C23A9DD1B00E1E98B /* InjectedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectedTests.swift; sourceTree = "<group>"; };
 		1B6B13D2217A7A9F004C1E76 /* LifecycleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleType.swift; sourceTree = "<group>"; };
 		1B6B13DC217A8BD6004C1E76 /* LifecycleTypeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleTypeExtensions.swift; sourceTree = "<group>"; };
 		1B779805217147D900DE8477 /* LinuxMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinuxMain.swift; sourceTree = "<group>"; };
 		1B77980D2171480D00DE8477 /* XCTestManifests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
 		1B80388C22B981EA00A48C56 /* DynamicTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTypes.swift; sourceTree = "<group>"; };
+		1BBFD51423A9A11700A7C3ED /* Injected.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Injected.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -350,6 +359,7 @@
 				1B47E443216FE49A00940349 /* DynamicDependencyIndexTests.swift */,
 				1B47E44E216FE49A00940349 /* DynamicDependencyRegistryTests.swift */,
 				1B47E44F216FE49A00940349 /* InjectDependenciesArgumentParserTests.swift */,
+				1B5F7A8C23A9DD1B00E1E98B /* InjectedTests.swift */,
 				1B170ECF21ED047000564994 /* OptionalExtensionTests.swift */,
 				1B47E445216FE49A00940349 /* Resources */,
 				1B47E44C216FE49A00940349 /* Util */,
@@ -369,6 +379,7 @@
 				1B47E3BB216FE34500940349 /* DependencyContainerScope.swift */,
 				1B47E3BD216FE34600940349 /* DependencyKey.swift */,
 				1B47E3D8216FE34700940349 /* DependencyRegistryType.swift */,
+				1BBFD51423A9A11700A7C3ED /* Injected.swift */,
 				1B6B13D2217A7A9F004C1E76 /* LifecycleType.swift */,
 			);
 			path = Relay;
@@ -827,6 +838,7 @@
 				1B47E405216FE34700940349 /* DependencyTypeKey.swift in Sources */,
 				1B47E40D216FE34700940349 /* InjectDependenciesArgumentParser.swift in Sources */,
 				1B47E419216FE34700940349 /* DependencyInjectionInstruction.swift in Sources */,
+				1BBFD51523A9A11700A7C3ED /* Injected.swift in Sources */,
 				1B47E48521700A2B00940349 /* LaunchArgument.swift in Sources */,
 				1B47E421216FE34700940349 /* DependencyTypeIndexable.swift in Sources */,
 				1B6B13D3217A7A9F004C1E76 /* LifecycleType.swift in Sources */,
@@ -858,6 +870,7 @@
 				1B47E406216FE34700940349 /* DependencyTypeKey.swift in Sources */,
 				1B47E40E216FE34700940349 /* InjectDependenciesArgumentParser.swift in Sources */,
 				1B47E41A216FE34700940349 /* DependencyInjectionInstruction.swift in Sources */,
+				1BBFD51623A9A11700A7C3ED /* Injected.swift in Sources */,
 				1B47E48621700A2B00940349 /* LaunchArgument.swift in Sources */,
 				1B47E422216FE34700940349 /* DependencyTypeIndexable.swift in Sources */,
 				1B6B13D4217A7A9F004C1E76 /* LifecycleType.swift in Sources */,
@@ -889,6 +902,7 @@
 				1B47E407216FE34700940349 /* DependencyTypeKey.swift in Sources */,
 				1B47E40F216FE34700940349 /* InjectDependenciesArgumentParser.swift in Sources */,
 				1B47E41B216FE34700940349 /* DependencyInjectionInstruction.swift in Sources */,
+				1BBFD51723A9A11700A7C3ED /* Injected.swift in Sources */,
 				1B47E48721700A2B00940349 /* LaunchArgument.swift in Sources */,
 				1B47E423216FE34700940349 /* DependencyTypeIndexable.swift in Sources */,
 				1B6B13D5217A7A9F004C1E76 /* LifecycleType.swift in Sources */,
@@ -920,6 +934,7 @@
 				1B47E408216FE34700940349 /* DependencyTypeKey.swift in Sources */,
 				1B47E410216FE34700940349 /* InjectDependenciesArgumentParser.swift in Sources */,
 				1B47E41C216FE34700940349 /* DependencyInjectionInstruction.swift in Sources */,
+				1BBFD51823A9A11700A7C3ED /* Injected.swift in Sources */,
 				1B47E48821700A2B00940349 /* LaunchArgument.swift in Sources */,
 				1B47E424216FE34700940349 /* DependencyTypeIndexable.swift in Sources */,
 				1B6B13D6217A7A9F004C1E76 /* LifecycleType.swift in Sources */,
@@ -934,6 +949,7 @@
 				1B47E453216FE49A00940349 /* DependencyInjectionInstructionTests.swift in Sources */,
 				1B47E471216FE49B00940349 /* DynamicDependencyRegistryTests.swift in Sources */,
 				1B47E46E216FE49B00940349 /* DynamicDependencyTestUtilities.swift in Sources */,
+				1B5F7A8D23A9DD1B00E1E98B /* InjectedTests.swift in Sources */,
 				1B2D6B9C2171011800CCB604 /* DependencyInstructionLaunchArgumentTests.swift in Sources */,
 				1B80388D22B981EA00A48C56 /* DynamicTypes.swift in Sources */,
 				1B47E468216FE49B00940349 /* DependencyContainerTests.swift in Sources */,
@@ -952,6 +968,7 @@
 				1B47E454216FE49A00940349 /* DependencyInjectionInstructionTests.swift in Sources */,
 				1B47E472216FE49B00940349 /* DynamicDependencyRegistryTests.swift in Sources */,
 				1B47E46F216FE49B00940349 /* DynamicDependencyTestUtilities.swift in Sources */,
+				1B5F7A8E23A9DD1B00E1E98B /* InjectedTests.swift in Sources */,
 				1B2D6B9D2171011800CCB604 /* DependencyInstructionLaunchArgumentTests.swift in Sources */,
 				1B80388E22B981EA00A48C56 /* DynamicTypes.swift in Sources */,
 				1B47E469216FE49B00940349 /* DependencyContainerTests.swift in Sources */,
@@ -972,6 +989,7 @@
 				1B170ED221ED047000564994 /* OptionalExtensionTests.swift in Sources */,
 				1B47E473216FE49B00940349 /* DynamicDependencyRegistryTests.swift in Sources */,
 				1B2D6B9E2171011800CCB604 /* DependencyInstructionLaunchArgumentTests.swift in Sources */,
+				1B5F7A8F23A9DD1B00E1E98B /* InjectedTests.swift in Sources */,
 				1B47E46A216FE49B00940349 /* DependencyContainerTests.swift in Sources */,
 				1B7798102171480D00DE8477 /* XCTestManifests.swift in Sources */,
 				1B80388F22B981EA00A48C56 /* DynamicTypes.swift in Sources */,

--- a/Sources/Relay/Injected.swift
+++ b/Sources/Relay/Injected.swift
@@ -1,0 +1,43 @@
+//
+//  Injected.swift
+//  Relay
+//
+//  Created by John Hammerlund on 12/17/19.
+//
+
+#if swift(>=5.1)
+
+import Foundation
+
+/// Auto-injects a property via IoC container. Defaults to the global container.
+///
+/// Example:
+///
+///     class MyClass {
+///         // Retrieves mapped FooDependency from the global container
+///         @Injected var foo: FooDependency
+///         // Retrieves mapped BarDependency from the custom container
+///         @Injected(scope: .custom) var bar: BarDependency
+///     }
+///
+/// - Important: Dependency factories are invoked lazily.
+@propertyWrapper
+public struct Injected<Value> {
+
+    private let scope: DependencyContainerScope
+    public lazy var wrappedValue: Value = DependencyContainer.container(for: scope).resolve()
+
+    /// Applies auto-injection using the specified `DependencyContainer`
+    /// - Parameter scope: The IoC container scope used to resolve the dependency
+    public init(scope: DependencyContainerScope) {
+        self.scope = scope
+    }
+
+    /// Applies auto-injection using the global container
+    public init() {
+        self.init(scope: .global)
+    }
+
+}
+
+#endif

--- a/Tests/RelayTests/InjectedTests.swift
+++ b/Tests/RelayTests/InjectedTests.swift
@@ -1,0 +1,97 @@
+//
+//  InjectedTests.swift
+//  Relay
+//
+//  Created by John Hammerlund on 12/17/19.
+//
+
+#if swift(>=5.1)
+
+import XCTest
+import Relay
+
+private protocol TypeA: class { }
+private protocol TypeB: class { }
+private protocol TypeC: class { }
+private protocol TypeD: class { }
+private class ImplementsA: TypeA { }
+private class ImplementsB: TypeB { }
+private class ImplementsC: TypeC { }
+private class ImplementsD: TypeD { }
+
+extension DependencyContainerScope {
+    static let propertyWrapper = DependencyContainerScope("injected-tests")
+}
+
+// swiftlint:disable nesting
+
+final class InjectedTests: XCTestCase {
+
+    func testResolvesDependenciesFromGlobalContainer() throws {
+        let expectedDependency = ImplementsA()
+
+        DependencyContainer.global.register(TypeA.self) { _ in expectedDependency }
+
+        class SampleClass {
+            @Injected var implementsA: TypeA
+        }
+
+        let instance = SampleClass()
+
+        XCTAssert(instance.implementsA === expectedDependency)
+    }
+
+    func testResolvesDependenciesFromContextualContainer() throws {
+        let scope = DependencyContainerScope.propertyWrapper
+        let container = DependencyContainer.container(for: scope)
+
+        let expectedDependency = ImplementsB()
+
+        DependencyContainer.global.register(TypeB.self) { _ in
+            XCTFail("Factory should not be called")
+            return ImplementsB()
+        }
+        container.register(TypeB.self) { _ in expectedDependency }
+
+        class SampleClass {
+            @Injected(scope: .propertyWrapper) var implementsB: TypeB
+        }
+
+        let instance = SampleClass()
+
+        XCTAssert(instance.implementsB === expectedDependency)
+    }
+
+    func testLazilyInjectsPropertyValue() throws {
+        DependencyContainer.global.register(TypeC.self) { _ in
+            XCTFail("Factory should not be called")
+            return ImplementsC()
+        }
+
+        class SampleClass {
+            @Injected var implementsC: TypeC
+        }
+
+        _ = SampleClass()
+    }
+
+    func testAllowsValueReplacement() throws {
+        let injectedDependency = ImplementsD()
+        DependencyContainer.global.register(TypeD.self) { _ in
+            XCTFail("Factory should not be called")
+            return ImplementsD()
+        }
+
+        class SampleClass {
+            @Injected var implementsD: TypeD
+        }
+
+        let instance = SampleClass()
+        instance.implementsD = ImplementsD()
+
+        XCTAssert(instance.implementsD !== injectedDependency)
+    }
+
+}
+
+#endif


### PR DESCRIPTION
This pull request includes (pick all that apply):

- [ ] Bugfixes
- [x] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [x] Unit tests
- [ ] Other

### Summary
This takes advantage of `@propertyWrapper`, which was introduced in Swift 5.1 as the backbone to `@Binding` and other Apple-specific language features. Unlike `@Binding` and its counterparts, user-defined property wrappers are not limited to iOS 13+; they are instead bound by Swift version, as we would hope for.

The motivation behind this change is to make usage more declarative and easy-to-read. This also enforces initialization semantics across all usages, which prevents behavior inconsistencies between various components that use Relay for dependency injection.

**Will follow up with documentation updates if/when this is approved and merged.**

### Implementation
The new property-wrapper is simply called `@Injected`, which is handled through the `Injected<V>` property wrapper class. The attribute can optionally be fed a scope, but defaults to the `.global` scope. The result: much cleaner, easier-to-read code:

```swift
// BEFORE

class FooClass {
    var barDependency: BarType = DependencyContainer.global.resolve()
    var bazDependency: BazType = DependencyContainer.container(for: .myCustomScope).resolve()
}

// AFTER

class FooClass {
    @Injected var barDependency: BarType
    @Injected(scope: .myCustomScope) var bazDependency: BazType
}
```

### Test Plan
Includes unit tests and upgrades Travis CI to Xcode 11.3 to ensure tests are ran (requires Swift 5.1)
